### PR TITLE
Organiza subpáginas de arquitectura eléctrica

### DIFF
--- a/gabinete-robot/arquitectura-electrica.md
+++ b/gabinete-robot/arquitectura-electrica.md
@@ -1,12 +1,10 @@
 ---
-title: Robot
+title: Arquitectura Eléctrica
 layout: default
 parent: Gabinete Robot
 nav_order: 9
+has_children: true
 redirect_from:
   - /conexiones/arquitectura-electrica/
 ---
 
-Esta pagina se dividirá como la carpeta de interfaz-usuario, contendrá 3 archivos (el index, uno para camara y otro para el UR3 y otro para el gripper.(el del griper será parte del UR3, una sub pagina del ur3)
-
-Deja las paginas emparentadas correctamente, pero sin contenido

--- a/gabinete-robot/arquitectura-electrica/camara.md
+++ b/gabinete-robot/arquitectura-electrica/camara.md
@@ -1,0 +1,6 @@
+---
+title: Cámara
+layout: default
+parent: Arquitectura Eléctrica
+---
+

--- a/gabinete-robot/arquitectura-electrica/ur3.md
+++ b/gabinete-robot/arquitectura-electrica/ur3.md
@@ -1,0 +1,7 @@
+---
+title: UR3
+layout: default
+parent: Arquitectura Eléctrica
+has_children: true
+---
+

--- a/gabinete-robot/arquitectura-electrica/ur3/gripper.md
+++ b/gabinete-robot/arquitectura-electrica/ur3/gripper.md
@@ -1,0 +1,6 @@
+---
+title: Gripper
+layout: default
+parent: UR3
+---
+


### PR DESCRIPTION
## Summary
- define la página de Arquitectura Eléctrica como contenedor sin contenido para nuevas subpáginas
- agrega páginas vacías para la cámara, el UR3 y su gripper dentro de la jerarquía de Gabinete Robot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbe26679c48327804235752a960674