### PR TITLE
Expandir índices del gabinete y robot

### DIFF
--- a/gabinete-robot/index.md
+++ b/gabinete-robot/index.md
@@ -9,4 +9,30 @@ redirect_from:
   - /estructura/
 ---
 
-Esta sección concentra la infraestructura física, cableado y dispositivos ubicados en el gabinete del robot. Recorre de lo general a lo particular las interfaces embebidas, la recepción de residuos, la robótica y la red local, manteniendo la información técnica previamente distribuida en "Conexiones" y "Estructura".
+El gabinete del robot integra la infraestructura física, el cableado y los subsistemas electrónicos que permiten que el robot de reciclaje opere de forma autónoma y segura. Aquí se recopilan los elementos que antes estaban dispersos en las secciones de «Conexiones» y «Estructura», ofreciendo una lectura de lo general a lo particular.
+
+## ¿Qué encontrarás en esta sección?
+
+- **Topología general del gabinete.** Incluye la disposición de perfiles, la distribución de volúmenes útiles y los criterios que guiaron la integración mecánica de los diferentes módulos.
+- **Interfaces de usuario locales.** Desde la HMI hasta el módulo RFID, detallando cómo se concibe la experiencia para la persona que deposita residuos.
+- **Subsistemas robóticos y sensores.** El brazo UR3, la cámara de visión y los elementos que habilitan la clasificación.
+- **Red, cómputo y recepción de residuos.** Un repaso por la electrónica de potencia, la red local y el manejo de los contenedores.
+
+Cada subsección profundiza en su propio «qué» y «cómo», describiendo componentes, conexiones y configuraciones relevantes.
+
+## Cómo navegar la documentación
+
+1. Comienza por **[Interfaz de usuario](./interfaz-usuario.html)** para entender la interacción con la persona operadora y los mecanismos de identificación.
+2. Continúa con **[Recepción de residuos](./recepcion-residuos.html)** para conocer la mecánica de los depósitos y el acoplamiento con el robot.
+3. Revisa **[Robot](./robot_.html)** para tener un panorama de los actuadores, sensores y elementos de control del brazo UR3.
+4. Finaliza en **[Computadora y red](./computadora-red.html)** si necesitas detalles de la conectividad, switching y administración remota.
+
+Estas páginas están pensadas como un hilo conductor: puedes leerlas de principio a fin para obtener un panorama completo o consultarlas de forma puntual cuando necesites información específica de cada módulo.
+
+## Convenciones y alcance
+
+- Se utilizan unidades métricas (mm) para dimensiones y referencias espaciales.
+- Las conexiones eléctricas se describen con el nombre real de los puertos y, cuando aplica, con el código de color del cableado.
+- Las fotografías, diagramas y esquemas eléctricos se enlazan desde las subpáginas correspondientes para mantener este índice ligero y enfocado en el contexto general.
+
+Con esta guía podrás ubicar rápidamente dónde se documenta cada elemento del gabinete y cómo se relaciona con los demás subsistemas del robot.

--- a/gabinete-robot/interfaz-usuario.md
+++ b/gabinete-robot/interfaz-usuario.md
@@ -8,12 +8,28 @@ redirect_from:
   - /conexiones/embebido-lector-rfid/
 ---
 
-La interfaz de usuario está compuesta por dos bloques principales:
+La interfaz de usuario del robot es el punto de contacto directo con la persona que deposita los residuos. Está pensada para guiar la interacción de forma intuitiva, brindar retroalimentación inmediata y permitir un diagnóstico rápido por parte del equipo técnico.
 
-- Una **HMI** gobernada por una Raspberry Pi que centraliza la interacción local con el usuario.
-- Un **módulo RFID** embebido que se encarga de identificar tarjetas y entregar confirmaciones auditivas.
+## Componentes principales
 
-En las siguientes subpáginas se detalla cada una de estas piezas.
+| Módulo | Función | Interacción clave |
+| --- | --- | --- |
+| **HMI basada en Raspberry Pi** | Presenta instrucciones, confirma acciones y habilita el flujo de trabajo del depósito. | Pantalla táctil de 7" con interfaz gráfica dedicada. |
+| **Módulo RFID embebido** | Identifica tarjetas de usuarios autorizados y genera confirmaciones sonoras. | Antena frontal, lector integrado y buzzer de notificación. |
 
-- [Diseño de la PCB del módulo RFID](./interfaz-usuario/diseno-pcb.html)
-- [Interfaz HMI](./interfaz-usuario/hmi.html)
+Ambos módulos comparten alimentación desde el gabinete y se comunican con el sistema principal a través de la red local interna.
+
+## Flujo de interacción
+
+1. La persona usuaria acerca su tarjeta RFID, activando la autenticación y el registro del depósito.
+2. La HMI despliega el estado del sistema (disponible, en proceso o en mantenimiento) y guía los pasos a seguir.
+3. Si se detecta alguna condición de error, la interfaz muestra mensajes específicos y ofrece instrucciones de recuperación.
+
+Este flujo permite mantener la operación autónoma, al tiempo que habilita un modo de servicio donde el personal técnico puede acceder a opciones avanzadas desde la propia HMI.
+
+## Cómo profundizar
+
+- Revisa el **[diseño de la PCB del módulo RFID](./interfaz-usuario/diseno-pcb.html)** para conocer la distribución de componentes, el ruteo y la lógica de validación.
+- Explora la página de la **[interfaz HMI](./interfaz-usuario/hmi.html)** para ver capturas de la aplicación, dependencias de software y pautas de despliegue.
+
+Cada subpágina incluye diagramas, listas de materiales y notas de implementación que complementan este resumen de alto nivel.

--- a/gabinete-robot/robot_.md
+++ b/gabinete-robot/robot_.md
@@ -8,3 +8,20 @@ redirect_from:
   - /conexiones/arquitectura-electrica/
 ---
 
+Esta sección concentra los elementos directamente involucrados en la manipulación de residuos: el brazo colaborativo UR3, los sensores de visión y los accesorios que le permiten operar dentro del gabinete.
+
+## Alcance del sistema robótico
+
+- **Brazo UR3.** Montaje mecánico, cableado de potencia y lógica de seguridad asociada a paros de emergencia.
+- **Percepción.** Cámara RGB-D y accesorios de iluminación que alimentan al algoritmo de clasificación.
+- **Herramental final.** Adaptadores, grippers y piezas impresas en 3D que permiten manipular los envases.
+
+Cada componente está descrito en las subpáginas que se listan a continuación, incluyendo conexiones, parámetros de calibración y recomendaciones de mantenimiento.
+
+## Guía de lectura
+
+1. Comienza por el **[brazo UR3](./robot/ur3.html)** para conocer su integración mecánica, el ruteo de cables y las rutinas de homeado.
+2. Continúa con la **[cámara](./robot/camara.html)** para entender la configuración óptica, el montaje y el enlace con el stack de visión.
+3. Consulta los anexos dentro de cada página para revisar listas de repuestos, versiones de firmware y pasos de diagnóstico.
+
+Este índice busca ofrecer un mapa claro de todos los elementos que orbitan al robot, facilitando la transición desde el diseño conceptual hasta la operación diaria.


### PR DESCRIPTION
## Summary
- Ampliar el índice principal del gabinete para describir subsistemas y ruta de navegación
- Documentar componentes y flujo de la interfaz de usuario con tabla y guía de lectura
- Redactar la introducción y alcance del índice de robot destacando UR3 y cámara

## Testing
- Not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68fbf662aa808327aecb2e28714cf123